### PR TITLE
fixed tablet & mobile adjusting to device size

### DIFF
--- a/LESS/about-us.less
+++ b/LESS/about-us.less
@@ -113,7 +113,7 @@
             }
 
             @media @mobile {
-                margin: auto;
+                margin: 0;
             } 
             
             button {
@@ -127,17 +127,17 @@
                 width: 100%;
 
                 @media @tablet {
-                    margin: 5% auto;
-                    padding: 4% 8%;
+                    margin: 5% 3%;
+                    padding: 1em 0.4em;
                     border: 1px solid @border-theme;
-                    width: auto;
+                    width: 100%;
                 }
 
                 @media @mobile {
-                    margin: 4% auto;
-                    padding: 3% 10%;
+                    margin: 4% 3%;
+                    padding: 1em 0.4em;
                     border: 1px solid @border-theme;
-                    width: auto;
+                    width: 100%;
                 }
 
                 a {

--- a/LESS/global.less
+++ b/LESS/global.less
@@ -28,10 +28,14 @@ h5 {
 
   @media @mobile {
     max-width: 515px;
+    width: 100%;
+    margin: 0 auto;
   }
 
   @media @tablet {
     width: 900px;
+    width: 100%;
+    margin: 0 auto;
   }
 }
 

--- a/css/index.css
+++ b/css/index.css
@@ -149,11 +149,15 @@ h5 {
 @media (max-width: 515px) {
   .container {
     max-width: 515px;
+    width: 100%;
+    margin: 0 auto;
   }
 }
 @media (max-width: 900px) {
   .container {
     width: 900px;
+    width: 100%;
+    margin: 0 auto;
   }
 }
 a :visited :hover :active :link {
@@ -682,7 +686,7 @@ header .index-header-m {
 }
 @media (max-width: 515px) {
   .about-body div .links {
-    margin: auto;
+    margin: 0;
   }
 }
 .about-body div .links button {
@@ -697,18 +701,18 @@ header .index-header-m {
 }
 @media (max-width: 900px) {
   .about-body div .links button {
-    margin: 5% auto;
-    padding: 4% 8%;
+    margin: 5% 3%;
+    padding: 1em 0.4em;
     border: 1px solid #5467ca;
-    width: auto;
+    width: 100%;
   }
 }
 @media (max-width: 515px) {
   .about-body div .links button {
-    margin: 4% auto;
-    padding: 3% 10%;
+    margin: 4% 3%;
+    padding: 1em 0.4em;
     border: 1px solid #5467ca;
-    width: auto;
+    width: 100%;
   }
 }
 .about-body div .links button a {


### PR DESCRIPTION
Previously, window sizes less than 900px or 515px were showing pages 900px or 515px exactly on the respective screen sizes. page should scale to device/window size properly now.  updated buttons on about-me for tablet and mobile - which were not sizing properly as well.